### PR TITLE
feat(frontend): Allow add or delete problem in Exam Edit

### DIFF
--- a/frontend/src/components/ExamCreation/ExamDataInputs.js
+++ b/frontend/src/components/ExamCreation/ExamDataInputs.js
@@ -75,7 +75,11 @@ class ExamDataInputs extends React.Component {
 
         <Form.Group controlId="language">
           <Form.Label>Idioma del examen</Form.Label>
-          <Form.Control onChange={this.props.handleInputChange} as="select">
+          <Form.Control
+            name="language"
+            onChange={this.props.handleInputChange}
+            as="select"
+          >
             <option value="EN">Ingles</option>
             <option value="ES">Español</option>
           </Form.Control>

--- a/frontend/src/components/ExamEdit/EditExamDataInputs.js
+++ b/frontend/src/components/ExamEdit/EditExamDataInputs.js
@@ -6,7 +6,6 @@ class EditExamDataInputs extends React.Component {
    * Component that represents all inputs that the user has to manually enter or type
    */
   render() {
-    console.log(this.props);
     return (
       <>
         <EditFormInput

--- a/frontend/src/components/ExamEdit/EditExamForm.js
+++ b/frontend/src/components/ExamEdit/EditExamForm.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Form, Button, Col } from "react-bootstrap";
 import EditExamDataInputs from "./EditExamDataInputs";
+import EditExamProblemInputs from "./EditExamProblemInputs";
 import EditFormSubmitButton from "./EditFormSubmitButton";
 
 class EditExamForm extends React.Component {
@@ -28,15 +29,12 @@ class EditExamForm extends React.Component {
     this.handleProblemSelection = this.handleProblemSelection.bind(this);
   }
 
-  handleProblemSelection(name, author) {
+  handleProblemSelection(list) {
     /**
      * Handle the event when a problem is selected in the form
      */
     this.setState({
-      problems: {
-        name: name,
-        author: author,
-      },
+      problems: list,
     });
   }
 
@@ -91,7 +89,6 @@ class EditExamForm extends React.Component {
     const target = event.target;
     const value = target.value;
     const name = target.name;
-    console.log("Modificando: " + name + " -> " + value);
     this.setState({
       [name]: value,
     });
@@ -109,7 +106,6 @@ class EditExamForm extends React.Component {
       .then((res) => res.json())
       .then(
         (result) => {
-          console.log("Result es " + result);
           this.setState({
             isLoaded: true,
             name: result.name,
@@ -134,7 +130,6 @@ class EditExamForm extends React.Component {
   }
 
   render() {
-    console.log(this.state);
     const style = {
       borderRadius: "5px",
       border: "2px solid teal",
@@ -151,6 +146,10 @@ class EditExamForm extends React.Component {
               <EditExamDataInputs
                 data={this.state}
                 handleInputChange={this.handleInputChange}
+              />
+              <EditExamProblemInputs
+                data={this.state.problems}
+                handleSelect={this.handleProblemSelection}
               />
             </div>
           </Form>

--- a/frontend/src/components/ExamEdit/EditExamProblemInputs.js
+++ b/frontend/src/components/ExamEdit/EditExamProblemInputs.js
@@ -1,0 +1,196 @@
+import React from "react";
+import { Form, Button } from "react-bootstrap";
+import { Col, Row } from "react-bootstrap";
+import { XCircleFill } from "react-bootstrap-icons";
+
+class SelectProblem extends React.Component {
+  /**
+   * Component which represent the select html of which the problems show and can be selected for
+   *
+   * The state represents:
+   *  error: If an error is produced while the problems are retrieved
+   *  problems: List of problems objects serialized, that are going to be displayed on the interface
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      problems: [],
+    };
+    this.handleChange = this.handleChange.bind(this);
+    this.removeProblem = this.removeProblem.bind(this);
+  }
+
+  removeProblem(event) {
+    let index = this.props.number;
+    this.props.removeProblem(index);
+  }
+
+  componentDidMount() {
+    /**
+     * When the component mounts, the problems have to be retrieved from the backend
+     */
+    let token = localStorage.getItem("token");
+    fetch("/api/problems/list", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${token}`,
+      },
+    })
+      .then((res) => res.json())
+      .then(
+        (result) =>
+          this.setState((state, props) => {
+            return { problems: result };
+          }),
+        (error) => {
+          this.setState((state, props) => {
+            return { error: error };
+          });
+        }
+      );
+  }
+  handleChange(event) {
+    /**
+     * On change, tell the parent which problems was chosen with the name and the author.
+     */
+    const target = event.target;
+    const value = target.value;
+    const problem_information = value.split(" -!-! ");
+    const author = problem_information[0];
+    const name = problem_information[1];
+    this.props.updateProblem(this.props.number, name, author);
+  }
+  render() {
+    const { problems } = this.state;
+    return (
+      <>
+        <Row>
+          <Col sm={10}>
+            <Form.Group controlId="problem1">
+              <Form.Label>Problema {this.props.number + 1}</Form.Label>
+              <Form.Control
+                onChange={this.handleChange}
+                as="select"
+                value={`${this.props.author} -!-! ${this.props.name}`}
+              >
+                <option key={0} value={`DEFAULT -!-! DEFAULT`}>
+                  {" "}
+                  No ha seleccionado Problema
+                </option>
+                {problems.map((problem, i) => {
+                  return (
+                    <option
+                      key={i + 1}
+                      value={`${problem.author} -!-! ${problem.name}`}
+                    >
+                      {problem.author} -- {problem.name}
+                    </option>
+                  );
+                })}
+              </Form.Control>
+            </Form.Group>
+          </Col>
+          <Col sm={2}>
+            <XCircleFill onClick={this.removeProblem} />
+          </Col>
+        </Row>
+      </>
+    );
+  }
+}
+class ExamProblemInputs extends React.Component {
+  /**
+   * Component on which the user selects the problem to be added to her's or he's exams.
+   * The state represents:
+   *  The number of maximum problems that the exam can have
+   *  The number of current problems that the exam currently has
+   *  The problems selection components that will be rendered
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      maximum: 5,
+      problems: this.props.data,
+    };
+    this.addProblem = this.addProblem.bind(this);
+    this.removeProblem = this.removeProblem.bind(this);
+    this.updateProblem = this.updateProblem.bind(this);
+  }
+  addProblem(event) {
+    /**
+     * Method on which the component add a problem select component to the interface
+     */
+    event.preventDefault();
+    const { current, problems, maximum } = this.state;
+    if (problems.length === maximum) {
+      alert(`Can't put more than ${maximum}`);
+      return;
+    }
+    problems.push({ name: "DEFAULT", author: "DEFAULT" });
+    this.setState((state, props) => {
+      return {
+        problems: problems,
+      };
+    });
+  }
+
+  removeProblem(index) {
+    /**
+     * Method on which the component remove a problem select component of the interface
+     */
+    let list = this.state.problems;
+    if (list.length === 1) {
+      alert("Cant submit exam with 0 problems");
+      return;
+    }
+    list.splice(index, 1);
+    this.setState((state, props) => {
+      return {
+        problems: list,
+      };
+    });
+  }
+
+  updateProblem(index, name, author) {
+    let list = this.state.problems;
+    list[index].name = name;
+    list[index].author = author;
+    this.setState((state, props) => {
+      return {
+        problems: list,
+      };
+    });
+
+    this.props.handleSelect(list);
+  }
+
+  render() {
+    const problems = this.state.problems;
+    return (
+      <>
+        <h3 style={{ center: true }}>Problemas</h3>
+        {problems.map((problem, i) => {
+          return (
+            <SelectProblem
+              key={i}
+              handleSelect={this.props.handleSelect}
+              number={i}
+              updateProblem={this.updateProblem}
+              removeProblem={this.removeProblem}
+              author={problem.author}
+              name={problem.name}
+            />
+          );
+        })}
+        <Button variant="primary" type="button" onClick={this.addProblem} block>
+          {" "}
+          Add other problem
+        </Button>{" "}
+      </>
+    );
+  }
+}
+
+export default ExamProblemInputs;


### PR DESCRIPTION
## Proposito

Permitir agregar o eliminar preguntas al momento de editar un examen.

## Resolución

La solución es equivalente a permitir agregar o eliminar preguntas al momento de crear el examen, es decir, se utiliza el mismo flujo.

## Donde empezar?

EditExamForm.js
EditExamProblemInputs.js
