### PR TITLE
feat(frontend): Allow add or delete Topics in Edit Question

### DIFF
--- a/frontend/src/components/Question_Edit/EditQuestion.js
+++ b/frontend/src/components/Question_Edit/EditQuestion.js
@@ -22,9 +22,6 @@ class EditQuestion extends React.Component {
             <Col>
               <QuestionEditForm uuid={uuid} />
             </Col>
-            <Col>
-              <RenderPDF />
-            </Col>
           </Row>
         </Container>
       </>

--- a/frontend/src/components/Question_Edit/EditTopicInputs.js
+++ b/frontend/src/components/Question_Edit/EditTopicInputs.js
@@ -1,0 +1,175 @@
+import React from "react";
+import { Form, Button } from "react-bootstrap";
+import { Col, Row } from "react-bootstrap";
+import { XCircleFill } from "react-bootstrap-icons";
+
+class SelectTopic extends React.Component {
+  /**
+   * Component which represent the select html of which the problems show and can be selected for
+   *
+   * The state represents:
+   *  error: If an error is produced while the problems are retrieved
+   *  problems: List of problems objects serialized, that are going to be displayed on the interface
+   */
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null,
+      available_topics: [],
+    };
+    this.handleChange = this.handleChange.bind(this);
+    this.removeTopic = this.removeTopic.bind(this);
+  }
+
+  removeTopic(event) {
+    let index = this.props.number;
+    this.props.removeTopic(index);
+  }
+
+  componentDidMount() {
+    let token = localStorage.getItem("token");
+    fetch("/api/topics/list/", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Token ${token}`,
+      },
+    })
+      .then(
+        (response) => response.json(),
+        (errors) => console.log(errors)
+      )
+      .then((data) => {
+        this.setState({ available_topics: data });
+      });
+  }
+
+  handleChange(event) {
+    /**
+     * On change, tell the parent which problems was chosen with the name and the author.
+     */
+    const target = event.target;
+    const value = target.value;
+    this.props.updateTopic(this.props.number, value);
+  }
+  render() {
+    const topics = this.state.available_topics;
+    return (
+      <>
+        <Row>
+          <Col sm={10}>
+            <Form.Group controlId="topic 1">
+              <Form.Label>Tópico {this.props.number + 1}</Form.Label>
+              <Form.Control
+                onChange={this.handleChange}
+                as="select"
+                value={this.props.name}
+              >
+                <option key={0} value="DEFAULT">
+                  Seleccione Tópico
+                </option>
+                {topics.map((topic, i) => {
+                  return (
+                    <option key={i + 1} value={topic.name}>
+                      {topic.name}
+                    </option>
+                  );
+                })}
+              </Form.Control>
+            </Form.Group>
+          </Col>
+          <Col sm={2}>
+            <XCircleFill onClick={this.removeTopic} />
+          </Col>
+        </Row>
+      </>
+    );
+  }
+}
+class TopicInputs extends React.Component {
+  /**
+   * Component on which the user selects the problem to be added to her's or he's exams.
+   * The state represents:
+   *  The number of maximum problems that the exam can have
+   *  The number of current problems that the exam currently has
+   *  The problems selection components that will be rendered
+   */
+  constructor(props) {
+    super(props);
+    console.log(this.props.data);
+    this.state = {
+      topics: this.props.data,
+    };
+    this.addTopic = this.addTopic.bind(this);
+    this.removeTopic = this.removeTopic.bind(this);
+    this.updateTopic = this.updateTopic.bind(this);
+  }
+  addTopic(event) {
+    /**
+     * Method on which the component add a problem select component to the interface
+     */
+    event.preventDefault();
+    const list = this.state.topics;
+    list.push("DEFAULT");
+    this.setState((state, props) => {
+      return {
+        topics: list,
+      };
+    });
+  }
+
+  removeTopic(index) {
+    /**
+     * Method on which the component remove a problem select component of the interface
+     */
+    let list = this.state.topics;
+    if (list.length === 1) {
+      alert("Cant submit exam with 0 topics");
+      return;
+    }
+    list.splice(index, 1);
+    this.setState((state, props) => {
+      return {
+        topics: list,
+      };
+    });
+  }
+
+  updateTopic(index, name) {
+    let list = this.state.topics;
+    list[index] = name;
+    this.setState((state, props) => {
+      return {
+        topics: list,
+      };
+    });
+
+    this.props.handleSelect(list);
+  }
+
+  render() {
+    const topics = this.state.topics;
+    return (
+      <>
+        {topics.map((topic, i) => {
+          return (
+            <SelectTopic
+              key={i}
+              handleSelect={this.props.handleSelect}
+              number={i}
+              updateTopic={this.updateTopic}
+              removeTopic={this.removeTopic}
+              name={topic}
+            />
+          );
+        })}
+        <Button variant="primary" type="button" onClick={this.addTopic} block>
+          {" "}
+          Agregar Tópico
+        </Button>{" "}
+      </>
+    );
+  }
+}
+
+export default TopicInputs;

--- a/frontend/src/components/Question_Edit/QuestionEditForm.js
+++ b/frontend/src/components/Question_Edit/QuestionEditForm.js
@@ -3,6 +3,7 @@ import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
 import Container from "react-bootstrap/Container";
 import SaveButton from "./SaveButton";
+import EditTopicInputs from "./EditTopicInputs";
 
 //Solo interfaz gráfica, falta conectar el backend para almacenar las preguntas
 //Falta la previsualización de las preguntas ingresadas.
@@ -38,15 +39,18 @@ class QuestionEditForm extends React.Component {
       .then((res) => res.json())
       .then(
         (result) => {
-          console.log("Result es " + result);
+          let list = [];
+          result.topics.map((topic, i) => {
+            list[i] = topic.name;
+          });
           this.setState({
             isLoaded: true,
             name: result.name,
             author: result.author,
             statement_content: result.statement_content,
             solution_content: result.solution_content,
-            topics_data: result.topics_data,
-            figures: result.figures,
+            topics_data: result.topics,
+            chosen_topics: list,
           });
         },
         (error) => {
@@ -56,20 +60,6 @@ class QuestionEditForm extends React.Component {
           });
         }
       );
-    fetch("/api/topics/list/", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Token ${token}`,
-      },
-    })
-      .then(
-        (response) => response.json(),
-        (errors) => console.log(errors)
-      )
-      .then((data) => {
-        this.setState({ available_topics: data });
-      });
   }
 
   handleChange(event) {
@@ -80,13 +70,12 @@ class QuestionEditForm extends React.Component {
       [name]: value,
     });
   }
-  handleTopicSelection(event) {
-    const target = event.target;
-    const value = target.value;
-    const { chosen_topics } = this.state;
-    chosen_topics.push(value);
+  handleTopicSelection(list) {
+    /**
+     * Handle the event when a problem is selected in the form
+     */
     this.setState({
-      chosen_topics: chosen_topics,
+      chosen_topics: list,
     });
   }
   handleSubmit(event) {
@@ -121,6 +110,7 @@ class QuestionEditForm extends React.Component {
       );
   }
   render() {
+    console.log(this.state);
     //Style
     const style = {
       borderRadius: "25px",
@@ -161,30 +151,11 @@ class QuestionEditForm extends React.Component {
       </Button>
     );
 
-    //Topicos
-    const topics = (
-      <Form.Group controlId="exampleForm.SelectCustomSizeSm">
-        <Form.Label>Topicos</Form.Label>
-        <Form.Control
-          onChange={this.handleTopicSelection}
-          as="select"
-          size="sm"
-          custom
-        >
-          {this.state.available_topics.map((topic) => {
-            return <option>{topic.name}</option>;
-          })}
-        </Form.Control>
-      </Form.Group>
-    );
-
     //Subir Imagenes
     const image = (
-      <Form>
-        <Form.Group>
-          <Form.File id="QuestionImage" label="Insertar Imagen" />
-        </Form.Group>
-      </Form>
+      <Form.Group>
+        <Form.File id="QuestionImage" label="Insertar Imagen" />
+      </Form.Group>
     );
 
     //Placeholder para botones Latex
@@ -207,8 +178,6 @@ class QuestionEditForm extends React.Component {
         <Button variant="dark"> &#10227; </Button>{" "}
       </>
     );
-    //Link Agregar Topicos
-    const addtopic = <a href="#addtopic">Agregar Tópico</a>;
 
     //Text Area Enunciado
     const enunciado = (
@@ -243,12 +212,16 @@ class QuestionEditForm extends React.Component {
     return (
       <div>
         <Form onSubmit={this.handleSubmit}>
-          <SaveButton />
+          {submit}
           <div style={style}>
             {questionName}
             {author}
-            {topics}
-            {addtopic}
+            {this.state.isLoaded && (
+              <EditTopicInputs
+                data={this.state.chosen_topics}
+                handleSelect={this.handleTopicSelection}
+              />
+            )}
             <p></p>
             {buttonsLtx}
             {enunciado}


### PR DESCRIPTION
## Proposito

Permitir eliminar o agregar topicos al momento de editar preguntas.

## Resolución

La solución es la misma que se utilizó para agregar o eliminar tópicos en creación de preguntas.

## Donde empezar?

QuestionEditForm.js, EditTopicInputs.js
