### PR TITLE
chore(frontend): Fix DateTime format in exam list.

### DIFF
--- a/frontend/src/components/ExamList/ExamRow.js
+++ b/frontend/src/components/ExamList/ExamRow.js
@@ -8,15 +8,27 @@ import DownloadExamButton from "./DownloadExamButton";
 class ExamRow extends React.Component {
   constructor(props) {
     super(props);
+    this.formatDate = this.formatDate.bind(this);
   }
+
+  formatDate(dateTime) {
+    let arr = dateTime.split("T");
+    let date = arr[0];
+    let time_arr = arr[1].split(".");
+    let time = time_arr[0];
+
+    return date + " a las " + time;
+  }
+
   render() {
     const url = "/exam/edit/" + this.props.exam.uuid;
+    let updated_at = this.formatDate(this.props.exam.updated_at);
     return (
       <tr>
         <td width="45%">
           <Link to={url}>{this.props.exam.name}</Link>
         </td>
-        <td width="45%"> {this.props.exam.updated_at}</td>
+        <td width="45%"> {updated_at}</td>
         <td width="10%">
           <DownloadExamButton
             uuid={this.props.exam.uuid}


### PR DESCRIPTION
## Proposito

Cambiar el formato de la fecha en el listado de exámenes.

## Resolución

Se hace split de la fecha de modificación. Se deja en formato "YYYY-MM-DD a las HH:MM:SS"

## Donde empezar?

ExamRow.js