### PR TITLE
Serializador de perfil de usuario que incluya is_admin

### DIFF
--- a/apps/user/serializers.py
+++ b/apps/user/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import (
     Serializer,
     EmailField,
     CharField,
+    BooleanField,
 )
 from apps.user.services import create_inactive_user_from_email
 from apps.user.models import Transaction
@@ -21,6 +22,7 @@ class UserSerializer(Serializer):
     email = EmailField(read_only=True)
     first_name = CharField()
     last_name = CharField()
+    is_admin = BooleanField(read_only=True)
 
     def update(self, instance, validated_data):
         instance.first_name = validated_data.get("first_name", instance.first_name)

--- a/apps/user/tests/test_serializers.py
+++ b/apps/user/tests/test_serializers.py
@@ -13,6 +13,7 @@ class TestUserSerializers(TestCase):
             "email": self.user.email,
             "first_name": self.user.first_name,
             "last_name": self.user.last_name,
+            "is_admin": self.user.is_admin,
         }
         serializer = serializers.UserSerializer(instance=self.user)
         self.assertEqual(serializer.data, user_data)

--- a/apps/user/tests/test_views.py
+++ b/apps/user/tests/test_views.py
@@ -85,6 +85,7 @@ def cosme_credentials():
                 "email": "cosme@fulanito.com",
                 "first_name": "Cosme",
                 "last_name": "Fulanito",
+                "is_admin": False,
             },
         )
     ],
@@ -112,6 +113,7 @@ def test_retrieve_information_from_view(
                 "email": "cosme@fulanito.com",
                 "first_name": "Homero",
                 "last_name": "Tompson",
+                "is_admin": False,
             },
         )
     ],


### PR DESCRIPTION

## Proposito
Incluir en el perfil de el usuario si es o no admin.
## Resolución
Añadir el atributo al serializador, arreglar los tests

## Donde empezar?
`serializers.py`
